### PR TITLE
Corrections in AdjectiveRus, NounRus, NumeralRus, etc.

### DIFF
--- a/lib/src/chunk/ChunkRus.gf
+++ b/lib/src/chunk/ChunkRus.gf
@@ -8,7 +8,6 @@ concrete ChunkRus of Chunk = CatRus, ExtensionsRus [VPS,VPI] **
     ResRus, (P = ParadigmsRus) in {
 
 lin VPI_Chunk vpi = {s = vpi.s} ;
---CN = {nounpart : NForm => Str; relcl : Number => Case => Str; g : Gender; anim : Animacy} ;  
 lin CN_Pl_Chunk, CN_Pl_Gen_Chunk = \cn -> {s = cn.nounpart ! NF Pl allCases allSizes ++ cn.relcl ! Pl ! allCases} ;
 lin CN_Sg_Chunk, CN_Sg_Gen_Chunk = \cn -> {s = cn.nounpart ! NF Sg allCases allSizes ++ cn.relcl ! Sg ! allCases} ;
 lin Conj_Chunk c = {s = c.s1 | c.s2 };

--- a/lib/src/chunk/ChunkRus.gf
+++ b/lib/src/chunk/ChunkRus.gf
@@ -8,9 +8,9 @@ concrete ChunkRus of Chunk = CatRus, ExtensionsRus [VPS,VPI] **
     ResRus, (P = ParadigmsRus) in {
 
 lin VPI_Chunk vpi = {s = vpi.s} ;
-
-lin CN_Pl_Chunk, CN_Pl_Gen_Chunk = \cn -> {s = cn.s ! NF Pl allCases allSizes} ;
-lin CN_Sg_Chunk, CN_Sg_Gen_Chunk = \cn -> {s = cn.s ! NF Sg allCases allSizes} ;
+--CN = {nounpart : NForm => Str; relcl : Number => Case => Str; g : Gender; anim : Animacy} ;  
+lin CN_Pl_Chunk, CN_Pl_Gen_Chunk = \cn -> {s = cn.nounpart ! NF Pl allCases allSizes ++ cn.relcl ! Pl ! allCases} ;
+lin CN_Sg_Chunk, CN_Sg_Gen_Chunk = \cn -> {s = cn.nounpart ! NF Sg allCases allSizes ++ cn.relcl ! Sg ! allCases} ;
 lin Conj_Chunk c = {s = c.s1 | c.s2 };
 lin IP_Chunk ip = {s = ip.s ! (PF allCases allAfterPrep allPossessive)};
 lin Predet_Chunk predet = {s = predet.s ! AF allCases allAnimacy allGenNum};
@@ -54,4 +54,5 @@ oper
   allSizes   = nom | nompl | sgg | plg ;
   allAfterPrep = Yes | No ;
   allPossessive = NonPoss | Poss (GSg allGender | GPl) ;
+
 }

--- a/lib/src/russian/AdjectiveRus.gf
+++ b/lib/src/russian/AdjectiveRus.gf
@@ -7,31 +7,35 @@ flags  coding=utf8 ;
 
   lin
 
-    PositA  a = { s = a.s!Posit; p = False};
+    PositA  a = { s = a.s!Posit ; p = a.p ; preferShort = a.preferShort};
        -- Comparative forms are used with an object of comparison, as
         -- adjectival phrases ("больше тебя").
 
     ComparA bolshoj tu =
           {s = \\af => bolshoj.s ! Compar ! af ++ tu.s ! (mkPronForm Gen Yes NonPoss) ; 
-            p = True
+           p = True ;
+           preferShort = PrefShort
            } ;
 
   ---- AR 17/12/2008
     UseComparA bolshoj =
           {s = \\af => bolshoj.s ! Compar ! af ;
-            p = True
+           p = True ;
+           preferShort = PrefShort
            } ;
 
   ---- AR 17/12/2008
     CAdvAP ad ap np = let adp = ad.s in  {  ---- should be ad.p
       s = \\af => ad.s ++ ap.s ! af ++ adp ++ np.s  ! (mkPronForm Gen Yes NonPoss) ; 
-      p = True ----?
+      p = True ; ----?
+      preferShort = ap.preferShort
       } ;
 
   ---- AR 17/12/2008
     AdjOrd  a = {
       s = a.s ;
-      p = True ---- ?
+      p = True ; ---- ?
+      preferShort = PrefFull
       } ;
 
 -- $SuperlA$ belongs to determiner syntax in $Noun$.
@@ -39,28 +43,33 @@ flags  coding=utf8 ;
     ComplA2 vlublen tu =
     {s = \\af => vlublen.s !Posit! af ++ vlublen.c2.s ++ 
           tu.s ! (mkPronForm vlublen.c2.c No NonPoss) ;
-     p = True
+     p = True ;
+     preferShort = vlublen.preferShort
     } ;
 
     ReflA2 vlublen = 
     {s = \\af => vlublen.s !Posit! af ++ vlublen.c2.s ++ sam.s ! vlublen.c2.c;
-     p = True
+     p = True ;
+     preferShort = vlublen.preferShort
     } ;
 
     SentAP vlublen sent= 
     {s = \\af => vlublen.s ! af ++ [", "] ++ sent.s;
-      p = True
+      p = True ;
+      preferShort = vlublen.preferShort
     } ;
 
 
     AdAP ada ap = {
       s = \\af => ada.s ++ ap.s ! af ;
-      p = True
+      p = True ;
+      preferShort = ap.preferShort
       } ;
 
     UseA2 a = {
       s = \\af => a.s ! Posit ! af ;
-      p = True
+      p = True ;
+      preferShort = a.preferShort
     } ;
 }
 

--- a/lib/src/russian/CatRus.gf
+++ b/lib/src/russian/CatRus.gf
@@ -40,11 +40,11 @@ concrete CatRus of Cat = CommonX ** open ResRus, Prelude in {
 
 -- Adjective
     
-    AP = {s : AdjForm => Str; p : IsPostfixAdj} ; 
+    AP = {s : AdjForm => Str ; p : IsPostfixAdj ; preferShort : ShortFormPreference} ; 
 
 -- Noun
 
-    CN = {s : NForm => Str; g : Gender; anim : Animacy} ;  
+    CN = {nounpart : NForm => Str; relcl : Number => Case => Str; g : Gender; anim : Animacy} ;  
     NP = { s : PronForm => Str ; n : Number ; p : Person ;
            g: PronGen ; anim : Animacy ;  pron: Bool} ;     
     Pron = { s : PronForm => Str ; n : Number ; p : Person ;
@@ -59,12 +59,13 @@ concrete CatRus of Cat = CommonX ** open ResRus, Prelude in {
 -- like "mnogo"
 -- The determined noun has the case parameter specific for the determiner
 
-    Det = {s : AdjForm => Str; n: Number; g: PronGen; c: Case; size: Size} ; 
+    Det = {s : Case => Animacy => Gender => Str; n: Number; g: PronGen; c: Case; size: Size} ; 
     Predet, Quant = {s : AdjForm => Str; g: PronGen; c: Case; size: Size} ; 
 
 -- Numeral
 
-    Num, Numeral, Card = {s : Gender => Animacy => Case => Str ; n : Number ; size: Size} ;
+    Num = {s : Gender => Animacy => Case => Str ; n : Number ; size: Size} ;
+    Numeral, Card = {s : Gender => Animacy => Case => Str ; n : Number ; size: Size} ;
     Digits = {s : Str ; n : Number ; size: Size} ; ---- 
     
 -- Structural
@@ -85,7 +86,7 @@ concrete CatRus of Cat = CommonX ** open ResRus, Prelude in {
 --    VV = {s : VVForm => Str ; isAux : Bool} ;
 
     Ord =  {s : AdjForm => Str} ;
-    A =  {s : Degree => AdjForm => Str} ;
+    A =  {s : Degree => AdjForm => Str ; p : IsPostfixAdj ; preferShort : ShortFormPreference} ;
     A2 = A ** {c2 : Complement} ;
 
  -- Substantives moreover have an inherent gender. 

--- a/lib/src/russian/ConjunctionRus.gf
+++ b/lib/src/russian/ConjunctionRus.gf
@@ -15,9 +15,18 @@ concrete ConjunctionRus of Conjunction =
     conjunctDistrTable PronForm c xs ** {n = conjNumber c.n xs.n ; 
       p = xs.p ; pron = xs.pron ; anim = xs.anim ; 
        g = xs.g } ;
-
-
-    ConjAP c xs = conjunctDistrTable AdjForm c xs ** {p = xs.p} ;
+        
+    ConjAP or xs = 
+      {s = \\af => case af of  {
+        AF c a gn => or.s1++ xs.s1 ! AF c a gn ++ or.s2 ++ xs.s2 ! AF c a gn ;
+        AFShort gn => case xs.preferShort of {
+          PrefShort => or.s1++ xs.s1 ! AFShort gn ++ or.s2 ++ xs.s2 ! AFShort gn ;
+          _ => or.s1++ xs.s1 ! AF Nom Inanimate gn ++ or.s2 ++ xs.s2 ! AF Nom Inanimate gn} ;
+        AdvF => or.s1++ xs.s1 ! AdvF ++ or.s2 ++ xs.s2 ! AdvF 
+        } ;
+     p = xs.p ;
+     preferShort = xs.preferShort 
+      } ;
 
   ---- AR 17/12/2008
     ConjRS c xs = conjunctDistrTable3 GenNum Case Animacy c xs ** {p = xs.p} ;
@@ -36,10 +45,9 @@ concrete ConjunctionRus of Conjunction =
           anim = conjAnim x.anim xs.anim ;
           p = conjPerson xs.p x.p; pron = conjPron xs.pron x.pron} ;
       
-    ConsAP x xs = consTable AdjForm comma xs x ** {p = andB xs.p x.p} ;
+    ConsAP x xs = consTable AdjForm comma xs x ** {p = andB xs.p x.p ; preferShort = selectAPForm x.preferShort xs.preferShort} ;
 
-
-    BaseAP x y = twoTable AdjForm x y ** {p = andB x.p y.p} ;
+    BaseAP x y = twoTable AdjForm x y ** {p = andB x.p y.p ; preferShort = selectAPForm x.preferShort y.preferShort} ;
 
     BaseNP x y = twoTable PronForm x y ** {n = conjNumber x.n y.n ; 
        g = conjPGender x.g y.g ; p = conjPerson x.p y.p ;
@@ -49,8 +57,13 @@ concrete ConjunctionRus of Conjunction =
     BaseRS x y = twoTable3 GenNum Case Animacy x y ** {c = y.c} ;
     ConsRS xs x = consrTable3 GenNum Case Animacy comma xs x ** {c = xs.c} ;
 
-
-
+  oper
+    selectAPForm : ShortFormPreference -> ShortFormPreference -> ShortFormPreference = \sfp1,sfp2 -> 
+      case <sfp1,sfp2> of 
+        {<PrefShort, PrefShort> => PrefShort ; 
+         _ => PrefFull
+        } ;
+  
   lincat
     [S] = {s1,s2 : Str} ;
     [Adv] = {s1,s2 : Str} ;
@@ -60,7 +73,7 @@ concrete ConjunctionRus of Conjunction =
              anim : Animacy ; n : Number ; p : Person ;  pron : Bool } ;
  -- The structure is the same as for sentences. The result is a prefix adjective
  -- if and only if all elements are prefix.
-    [AP] =  {s1,s2 : AdjForm => Str ; p : Bool} ;
+    [AP] =  {s1,s2 : AdjForm => Str ; p : Bool ; preferShort : ShortFormPreference} ;
 
   ---- AR 17/12/2008
    [RS] = {s1,s2 : GenNum => Case => Animacy => Str} ;

--- a/lib/src/russian/MorphoRus.gf
+++ b/lib/src/russian/MorphoRus.gf
@@ -826,9 +826,6 @@ oper eEnd_Decl: Str -> CommNoun =  \vs ->
 	 AdvF => stem + "е"
      } } ;
 
-
-
-
    vseDetPl: Adjective   =  extAdjFromSubst (eEnd_Decl "вс") ;
    extAdjFromSubst: CommNoun -> Adjective = \ vse ->
     {s = \\af => vse.s ! NF (numAF af) (caseAF af) plg } ;
@@ -1391,4 +1388,146 @@ oper ProperName : Type = {s :  Case => Str ; g : Gender ; anim : Animacy} ;
                      (Prepos _) => lubercy + "ах" };
           g = Neut ; anim = anim };
 
+  oper aRegHardWorstCase : AdjStress -> AdjType -> Str -> Str -> Str -> Str -> Str -> Adjective = \stress, at, stem, shortMasc, shortFem, shortNeut, shortPl ->
+    let i = iAfter stem in
+    let o = case stress of {
+	       EndStress  => "о" ;
+	       StemStress => oAfter stem } in
+    { s = table {
+	 AF Nom _ (GSg Masc)               => stem + case stress of {
+                                                        EndStress => "ой";
+							StemStress => iAfter stem + "й" } ;
+	 AF Nom _ (GSg Neut)               => stem + o+"е";
+	 AF Gen _ (GSg (Masc|Neut))        => stem + o+"го";
+	 AF Dat _ (GSg (Masc|Neut))        => stem + o+"му";
+	 AF Acc Inanimate (GSg Masc)       => stem + i+"й";
+	 AF Acc Animate (GSg Masc)         => stem + o+"го";
+	 AF Acc _ (GSg Neut)               => stem + o+"е";
+	 AF Inst _ (GSg (Masc|Neut))       => stem + i+"м";
+	 AF (Prepos _) _ (GSg (Masc|Neut)) => stem + o+"м";
+
+	 AF Nom  _ (GSg Fem) => stem + "ая";
+	 AF Acc  _ (GSg Fem) => stem + "ую";
+	 AF _    _ (GSg Fem) => stem + o+"й";
+
+	 AF Nom _ GPl          => stem + i+"е";
+	 AF Acc  Inanimate GPl => stem + i+"е";
+	 AF Acc  Animate GPl   => stem + i+"х";
+	 AF Gen  _ GPl         => stem + i+"х";
+	 AF Inst _ GPl         => stem + i+"ми";
+	 AF Dat  _ GPl         => stem + i+"м";
+	 AF (Prepos _) _ GPl   => stem + i+"х";
+
+	 AFShort (GSg Masc) => shortMasc ;
+	 AFShort (GSg Fem)  => shortFem ;
+	 AFShort (GSg Neut) => shortNeut ;
+	 AFShort GPl        => shortPl ;
+
+	 AdvF => stem + o
+   } } ;
+
+-- Liza Zimina 04/2018: to make correct short forms of adjectives
+
+  oper aRegSoftWorstCase : AdjType -> Str -> Str -> Str -> Str -> Str -> Adjective = \at, stem, shortMasc, shortFem, shortNeut, shortPl ->
+    { s = table {
+	 AF Nom _ (GSg Masc)               => stem + "ий" ;
+	 AF Nom _ (GSg Neut)               => stem + "ее";
+	 AF Gen _ (GSg (Masc|Neut))        => stem + "его";
+	 AF Dat _ (GSg (Masc|Neut))        => stem + "ему";
+	 AF Acc Inanimate (GSg Masc)       => stem + "ий";
+	 AF Acc Animate (GSg Masc)         => stem + "его";
+	 AF Acc _ (GSg Neut)               => stem + "ее";
+	 AF Inst _ (GSg (Masc|Neut))       => stem + "им";
+	 AF (Prepos _) _ (GSg (Masc|Neut)) => stem + "ем";
+
+	 AF Nom  _ (GSg Fem) => stem + "яя";
+	 AF Acc  _ (GSg Fem) => stem + "юю";
+	 AF _    _ (GSg Fem) => stem + "ей";
+
+	 AF Nom _ GPl          => stem + "ие";
+	 AF Acc  Inanimate GPl => stem + "ие";
+	 AF Acc  Animate GPl   => stem + "их";
+	 AF Gen  _ GPl         => stem + "их";
+	 AF Inst _ GPl         => stem + "ими";
+	 AF Dat  _ GPl         => stem + "им";
+	 AF (Prepos _) _ GPl   => stem + "их";
+
+	 AFShort (GSg Masc) => shortMasc ;
+	 AFShort (GSg Fem)  => shortFem ;
+	 AFShort (GSg Neut) => shortNeut ;
+	 AFShort GPl        => shortPl ;
+	 AdvF => stem + "е"
+   } } ;
+   
+   oper aRegHardFull : AdjStress -> AdjType -> Str -> Adjective = \stress, at, stem ->
+     let i = iAfter stem in
+     let o = case stress of {
+ 	       EndStress  => "о" ;
+ 	       StemStress => oAfter stem } in
+     { s = table {
+ 	 AF Nom _ (GSg Masc)               => stem + case stress of {
+                                                         EndStress => "ой";
+ 							StemStress => iAfter stem + "й" } ;
+ 	 AF Nom _ (GSg Neut)               => stem + o+"е";
+ 	 AF Gen _ (GSg (Masc|Neut))        => stem + o+"го";
+ 	 AF Dat _ (GSg (Masc|Neut))        => stem + o+"му";
+ 	 AF Acc Inanimate (GSg Masc)       => stem + i+"й";
+ 	 AF Acc Animate (GSg Masc)         => stem + o+"го";
+ 	 AF Acc _ (GSg Neut)               => stem + o+"е";
+ 	 AF Inst _ (GSg (Masc|Neut))       => stem + i+"м";
+ 	 AF (Prepos _) _ (GSg (Masc|Neut)) => stem + o+"м";
+
+ 	 AF Nom  _ (GSg Fem) => stem + "ая";
+ 	 AF Acc  _ (GSg Fem) => stem + "ую";
+ 	 AF _    _ (GSg Fem) => stem + o+"й";
+
+ 	 AF Nom _ GPl          => stem + i+"е";
+ 	 AF Acc  Inanimate GPl => stem + i+"е";
+ 	 AF Acc  Animate GPl   => stem + i+"х";
+ 	 AF Gen  _ GPl         => stem + i+"х";
+ 	 AF Inst _ GPl         => stem + i+"ми";
+ 	 AF Dat  _ GPl         => stem + i+"м";
+ 	 AF (Prepos _) _ GPl   => stem + i+"х";
+
+ 	 AFShort (GSg Masc) => stem + case stress of {
+              EndStress => "ой";
+ 							StemStress => iAfter stem + "й" } ;
+ 	 AFShort (GSg Fem)  => stem + "ая";
+ 	 AFShort (GSg Neut) => stem + o+"е";
+ 	 AFShort GPl        => stem + i+"е";
+
+ 	 AdvF => stem + o
+      } } ;
+
+   oper aRegSoftFull : AdjType -> Str -> Adjective = \at, stem ->
+     { s = table {
+ 	 AF Nom _ (GSg Masc)               => stem + "ий" ;
+ 	 AF Nom _ (GSg Neut)               => stem + "ее";
+ 	 AF Gen _ (GSg (Masc|Neut))        => stem + "его";
+ 	 AF Dat _ (GSg (Masc|Neut))        => stem + "ему";
+ 	 AF Acc Inanimate (GSg Masc)       => stem + "ий";
+ 	 AF Acc Animate (GSg Masc)         => stem + "его";
+ 	 AF Acc _ (GSg Neut)               => stem + "ее";
+ 	 AF Inst _ (GSg (Masc|Neut))       => stem + "им";
+ 	 AF (Prepos _) _ (GSg (Masc|Neut)) => stem + "ем";
+
+ 	 AF Nom  _ (GSg Fem) => stem + "яя";
+ 	 AF Acc  _ (GSg Fem) => stem + "юю";
+ 	 AF _    _ (GSg Fem) => stem + "ей";
+
+ 	 AF Nom _ GPl          => stem + "ие";
+ 	 AF Acc  Inanimate GPl => stem + "ие";
+ 	 AF Acc  Animate GPl   => stem + "их";
+ 	 AF Gen  _ GPl         => stem + "их";
+ 	 AF Inst _ GPl         => stem + "ими";
+ 	 AF Dat  _ GPl         => stem + "им";
+ 	 AF (Prepos _) _ GPl   => stem + "их";
+
+ 	 AFShort (GSg Masc) => stem + "ий" ;
+ 	 AFShort (GSg Fem)  => stem + "яя";
+ 	 AFShort (GSg Neut) => stem + "ее";
+ 	 AFShort GPl        => stem + "ие";
+
+ 	 AdvF => stem + "е"
+      } } ;
 };

--- a/lib/src/russian/NounRus.gf
+++ b/lib/src/russian/NounRus.gf
@@ -5,30 +5,31 @@ concrete NounRus of Noun = CatRus ** open ResRus, Prelude, MorphoRus in {
   flags optimize=all_subs ; coding=utf8 ;
 
   lin
+  
     DetCN kazhduj okhotnik = {
       s = \\c => case kazhduj.size of {
 	nom =>
-              kazhduj.s ! AF (extCase c) okhotnik.anim (gennum okhotnik.g Sg) ++ 
-              okhotnik.s ! NF kazhduj.n (extCase c) nom  ;
+              kazhduj.s ! extCase c ! okhotnik.anim ! okhotnik.g ++ 
+              okhotnik.nounpart ! NF Sg (extCase c) nom ++ okhotnik.relcl ! kazhduj.n ! (extCase c) ;
 	nompl =>
-              kazhduj.s ! AF (extCase c) okhotnik.anim (gennum okhotnik.g Pl) ++ 
-              okhotnik.s ! NF kazhduj.n (extCase c) nompl  ;
+              kazhduj.s ! extCase c ! okhotnik.anim ! okhotnik.g ++ 
+              okhotnik.nounpart ! NF kazhduj.n (extCase c) nompl ++ okhotnik.relcl ! kazhduj.n ! (extCase c) ;
 	sgg =>
 	  case c of {
 	    PF Nom _ _ => 
-              kazhduj.s ! AF Nom okhotnik.anim (gennum okhotnik.g kazhduj.n) ++ 
-              okhotnik.s ! NF Sg Gen sgg; 
+              kazhduj.s ! Nom ! okhotnik.anim ! okhotnik.g ++ 
+              okhotnik.nounpart ! NF Sg Gen sgg ++ okhotnik.relcl ! kazhduj.n ! (extCase c) ; 
 	    _ => 
-              kazhduj.s ! AF (extCase c) okhotnik.anim (gennum okhotnik.g kazhduj.n) ++ 
-              okhotnik.s ! NF Pl (extCase c) sgg } ;
+              kazhduj.s ! extCase c ! okhotnik.anim ! okhotnik.g ++ 
+              okhotnik.nounpart ! NF Pl (extCase c) sgg ++ okhotnik.relcl ! kazhduj.n ! (extCase c)} ;
 	plg =>
 	  case c of {
 	    PF Nom _ _ => 
-              kazhduj.s ! AF Nom okhotnik.anim (gennum okhotnik.g kazhduj.n) ++ 
-              okhotnik.s ! NF Pl Gen plg ; 
+              kazhduj.s ! Nom ! okhotnik.anim ! okhotnik.g ++ 
+              okhotnik.nounpart ! NF Pl Gen plg ++ okhotnik.relcl ! kazhduj.n ! (extCase c) ; 
 	    _ => 
-              kazhduj.s ! AF (extCase c) okhotnik.anim (gennum okhotnik.g kazhduj.n) ++ 
-              okhotnik.s ! NF Pl (extCase c) plg }
+              kazhduj.s ! extCase c ! okhotnik.anim ! okhotnik.g ++ 
+              okhotnik.nounpart ! NF Pl (extCase c) plg ++ okhotnik.relcl ! kazhduj.n ! (extCase c)}
 	  };
       n = kazhduj.n ; 
       p = P3 ;
@@ -79,7 +80,7 @@ concrete NounRus of Noun = CatRus ** open ResRus, Prelude, MorphoRus in {
        g = Neut ; ----
        anim = Inanimate ;
      in {
-      s = \\c => kazhduj.s ! AF (extCase c) anim (gennum g kazhduj.n) ;
+      s = \\c => kazhduj.s ! extCase c ! anim ! g ;
       n = kazhduj.n ; 
       p = P3 ;
       pron = False;
@@ -87,21 +88,6 @@ concrete NounRus of Noun = CatRus ** open ResRus, Prelude, MorphoRus in {
       anim = anim 
     } ;
 
-    DetQuantOrd quant num ord = {
-      s =  \\af => quant.s !af ++ num.s ! (genAF af) ! (animAF af) ! (caseAF af)  ++ ord.s!af ; 
-      n = num.n ;
-      g = quant.g;
-      c = quant.c;
-      size = quant.size
-      } ;
-
-    DetQuant quant num = {
-      s =  \\af => quant.s !af ++ num.s ! (genAF af) ! (animAF af) ! (caseAF af);
-      n = num.n ;
-      g = quant.g;
-      c = quant.c;
-      size = num.size
-      } ;
 {-
     DetArtOrd quant num ord = {
       s =  \\af => quant.s !af ++ num.s! (caseAF af) ! (genAF af)  ++ ord.s!af ; 
@@ -117,10 +103,10 @@ concrete NounRus of Noun = CatRus ** open ResRus, Prelude, MorphoRus in {
       c = quant.c
       } ;
 -}
---    MassDet = {s = \\_=>[] ; c=Nom; g = PNoGen; n = Sg} ;
+--    MassDet = {s = \\_=>[] ; c = Nom; g = PNoGen; n = Sg} ;
 
     MassNP okhotnik = {
-      s = \\c => okhotnik.s ! NF Sg (extCase c) nom ; 
+      s = \\c => okhotnik.nounpart ! NF Sg (extCase c) nom ++ okhotnik.relcl ! Sg ! extCase c ; 
       n = Sg ; 
       p = P3 ;
       pron = False;
@@ -135,7 +121,7 @@ concrete NounRus of Noun = CatRus ** open ResRus, Prelude, MorphoRus in {
       n = Sg ; 
       p = P3 ;
       pron = False;
-      g = case kazhduj.g of { PNoGen => (PGen okhotnik.g); _ => kazhduj.g };
+      g = case kazhduj.g of { PNoGen => (PGen okhotnik.g); _ => kazhduj.g};
       anim = okhotnik.anim 
     } ;
 
@@ -152,10 +138,6 @@ concrete NounRus of Noun = CatRus ** open ResRus, Prelude, MorphoRus in {
 -}
     PossPron p = {s = \\af => p.s ! mkPronForm (caseAF af) No (Poss (gennum (genAF af) (numAF af) )); c=Nom; g = PNoGen; size = nom} ;
 
-   NumCard c = c ;
-   NumSg = {s = \\_,_,_ => [] ; n = Sg ; size = nom} ;
-   NumPl = {s = \\_,_,_ => [] ; n = Pl ; size = nompl} ;
-
    OrdNumeral numeral = variants {} ; ---- TODO; needed to compile Constructors
    OrdDigits numeral = variants {} ; ---- TODO; needed to compile Constructors
 ----   OrdDigits TODO
@@ -166,13 +148,24 @@ concrete NounRus of Noun = CatRus ** open ResRus, Prelude, MorphoRus in {
 
     AdNum adn num = {s = \\c,a,n => adn.s ++ num.s!c!a!n ; n = num.n ; size = num.size} ;
 
-    OrdSuperl a = {s = a.s!Posit};
+    OrdSuperl a = {s = a.s ! Posit} ;
 
     DefArt = {s = \\_=>[] ; c=Nom; g = PNoGen; size = nom };
     IndefArt = { s = \\_=>[] ; c=Nom; g = PNoGen; size = nom };
+  
+  UseN noun = {
+    nounpart = \\nf => noun.s ! nf ;
+    relcl = \\n,c => "" ;
+    g = noun.g ; 
+    anim = noun.anim 
+    } ;
 
-  UseN noun = noun ;
-  UseN2 noun = noun ;
+  UseN2 noun = {
+    nounpart = noun.s ;
+    relcl = \\n,c => "" ;
+    g = noun.g ; 
+    anim = noun.anim 
+    } ;
 
 -- The application of a function gives, in the first place, a common noun:
 -- "ключ от дома". From this, other rules of the resource grammar 
@@ -183,11 +176,12 @@ concrete NounRus of Noun = CatRus ** open ResRus, Prelude, MorphoRus in {
 -- of the readings is meaningful.
 
   ComplN2 f x = {
-    s = \\nf => case x.pron of {
+    nounpart = \\nf => case x.pron of {
                   True => x.s ! (case nf of {NF n c size => mkPronForm c No (Poss (gennum f.g n))}) ++ f.s ! nf ;
                   False => f.s ! nf ++ f.c2.s ++ 
                            x.s ! (case nf of {NF n c size => mkPronForm f.c2.c Yes (Poss (gennum f.g n))})
-                };
+                } ;
+    relcl = \\n,c => "" ;
     g = f.g ;
     anim = f.anim
     } ;
@@ -224,9 +218,13 @@ concrete NounRus of Noun = CatRus ** open ResRus, Prelude, MorphoRus in {
 -- later, in the chapter on verbs.
 
   AdjCN ap cn = {
-    s = \\nf => ap.s ! case nf of {NF Sg Gen sgg => AF Nom cn.anim GPl ;
-                                   NF n c size => AF c cn.anim (gennum cn.g n)} ++ 
-                cn.s ! nf ;
+    nounpart = \\nf => case ap.p of {
+      False => ap.s ! case nf of {NF Sg Gen sgg => AF Nom cn.anim GPl ;
+                                  NF n c size => AF c cn.anim (gennum cn.g n)} ++ cn.nounpart ! nf ;
+      True => cn.nounpart ! nf ++ ap.s ! case nf of {NF Sg Gen sgg => AF Nom cn.anim GPl ;
+                                                     NF n c size => AF c cn.anim (gennum cn.g n)} 
+      } ;
+    relcl = cn.relcl ;
     g = cn.g ;
     anim = cn.anim
     } ;
@@ -236,7 +234,8 @@ concrete NounRus of Noun = CatRus ** open ResRus, Prelude, MorphoRus in {
 -- Semantics will have to make finer distinctions among adverbials.
 
   AdvCN cn adv = {
-    s = \\nf => cn.s ! nf ++ adv.s ;
+    nounpart = \\nf => cn.nounpart ! nf ++ adv.s ;
+    relcl = cn.relcl ;
     g = cn.g ;
     anim = cn.anim 
     } ;
@@ -245,20 +244,23 @@ concrete NounRus of Noun = CatRus ** open ResRus, Prelude, MorphoRus in {
 -- first place as common nouns, so that one can also have "a suggestion that...".
 
   SentCN idea x = {
-    s = \\nf => idea.s ! nf ++ x.s ; 
+    nounpart = \\nf => idea.nounpart ! nf ; 
+    relcl = \\n,c => idea.relcl ! n ! c ++ x.s ;
     g = idea.g ;
     anim = idea.anim
     } ;
 
   RelCN idea x = {
-    s = \\nf => idea.s ! nf ++ case nf of {NF n c size => x.s ! (gennum idea.g n)!c!idea.anim} ; 
+    nounpart = \\nf => idea.nounpart ! nf; 
+    relcl = \\n,c => idea.relcl ! n ! c ++ x.s ! (gennum idea.g n)! c ! idea.anim ;
     g = idea.g ;
     anim = idea.anim
     } ;
-
+ 
   ---- AR 17/12/2008
   ApposCN cn s = {
-    s = \\nf => cn.s ! nf ++ s.s ! (case nf of {NF n c size => PF c No NonPoss}) ; 
+    nounpart = \\nf => cn.nounpart ! nf ++ s.s ! (case nf of {NF n c size => PF c No NonPoss}) ; 
+    relcl = cn.relcl ;
     g = cn.g ;
     anim = cn.anim
     } ;
@@ -273,6 +275,30 @@ concrete NounRus of Noun = CatRus ** open ResRus, Prelude, MorphoRus in {
       nComp = np.nComp
       } ;
 
+---- Liza Zimina 04/2018
+-- changed to make Ord agree in number with Num
 
+  DetQuantOrd quant num ord = { 
+    s =  \\c,a,gen => quant.s ! AF c a (gennum gen num.n) ++ num.s ! gen ! a ! c  ++ case num.n of {
+      Sg => ord.s ! AF c a (GSg gen) ; 
+      Pl => ord.s ! AF c a GPl 
+      } ;
+    n = num.n ;
+    g = quant.g;
+    c = quant.c;
+    size = quant.size
+    } ;
+
+  DetQuant quant num = {
+    s =  \\c,a,gen => quant.s ! AF c a (gennum gen num.n) ++ num.s ! gen ! a ! c ;
+    n = num.n ;
+    g = quant.g;
+    c = quant.c;
+    size = num.size
+    } ;
+    
+  NumCard c = c ;
+  NumSg = {s = \\_,_,_ => [] ; n = Sg ; size = nom} ;
+  NumPl = {s = \\_,_,_ => [] ; n = Pl ; size = nompl} ;
 }
 

--- a/lib/src/russian/NumeralRus.gf
+++ b/lib/src/russian/NumeralRus.gf
@@ -15,27 +15,6 @@ lincat Sub1000000 = {s : Gender => Animacy => Case => Str ; size : Size} ;
 
 lin num x = {s = \\ g,a,c => x.s ! g ! a ! c; n = Pl ; size = x.size};
 
-lin n2  =
-  {s = table {unit => \\ g, a, c =>
-		case <c, g, a> of {
-		  <(Nom|Acc), Fem, Inanimate > => "две";
-		  <(Nom|Acc), _, Inanimate   > => "два";
-		  <Nom      , _, Animate     > => "два";
-		  <Acc      , _, Animate     > => "двух";
-		  <(Gen|Prepos _), _, _      > => "двух";
-		  <Dat, _, _                 > => "двум";
-		  <Inst, _, _                > => "двумя"
-		};
-              teen => nadsat "две" ;
-              ten  => n2030 "два" ;
-              hund => \\ g, a, c =>
-		case <c, g> of {
-		  <(Nom|Acc), _  >     => "двести";
-		  <Gen, _        >     => "двухсот";
-		  <Dat, _        >     => "двумстам";
-		  <Inst, _       >     => "двумяюстами";
-		  <Prepos _, _   >     => "двухстах"} } ;
-   size = sgg} ;
 lin n3  =
   {s = table {unit => tri ; 
               teen => nadsat "три" ;
@@ -195,6 +174,30 @@ lin pot01  =
 				 <Neut, _, Inst      > => "одним";
 				 <Neut, _, Prepos _  > => "одном"}}} ;
    size = nom} ;
+
+lin n2  =
+  {s = table {unit => \\ g, a, c =>
+		case <c, g, a> of {
+		  <(Nom|Acc), Fem, Inanimate > => "две";
+		  <(Nom|Acc), Masc, Inanimate   > => "два";
+      <(Nom|Acc), Neut, Inanimate   > => "два";
+		  <Nom      , _, Animate     > => "два";
+		  <Acc      , _, Animate     > => "двух";
+		  <(Gen|Prepos _), _, _      > => "двух";
+		  <Dat, _, _                 > => "двум";
+		  <Inst, _, _                > => "двумя"
+		};
+              teen => nadsat "две" ;
+              ten  => n2030 "два" ;
+              hund => \\ g, a, c =>
+		case <c, g> of {
+		  <(Nom|Acc), _  >     => "двести";
+		  <Gen, _        >     => "двухсот";
+		  <Dat, _        >     => "двумстам";
+		  <Inst, _       >     => "двумяюстами";
+		  <Prepos _, _   >     => "двухстах"} } ;
+   size = sgg} ;
+   
 lin pot0 d =
   {s = table {_ => d.s} ; size = d.size} ;
 lin pot110  =

--- a/lib/src/russian/NumeralRus.gf
+++ b/lib/src/russian/NumeralRus.gf
@@ -178,10 +178,9 @@ lin pot01  =
 lin n2  =
   {s = table {unit => \\ g, a, c =>
 		case <c, g, a> of {
-		  <(Nom|Acc), Fem, Inanimate > => "две";
-		  <(Nom|Acc), Masc, Inanimate   > => "два";
-      <(Nom|Acc), Neut, Inanimate   > => "два";
-		  <Nom      , _, Animate     > => "два";
+		  <(Nom|Acc), Fem, _ > => "две";
+		  <(Nom|Acc), (Masc|Neut), Inanimate   > => "два";
+		  <Nom, (Masc|Neut), Animate     > => "два";
 		  <Acc      , _, Animate     > => "двух";
 		  <(Gen|Prepos _), _, _      > => "двух";
 		  <Dat, _, _                 > => "двум";

--- a/lib/src/russian/PhraseRus.gf
+++ b/lib/src/russian/PhraseRus.gf
@@ -14,10 +14,10 @@ concrete PhraseRus of Phrase = CatRus ** open Prelude, ResRus in {
 
     UttIP ip = {s = ip.s ! PF Nom No NonPoss} ; --- Acc also
     UttIAdv iadv = iadv ;
-    UttNP np = {s = np.s ! PF Acc No NonPoss} ;
+    UttNP np = {s = np.s ! PF Nom No NonPoss} ; -- why was Acc instead of Nom here? (Liza Zimina 04/2018)
     UttVP vp = {s = vp.s ! ClInfinit ! GSg Masc ! P3} ;
     UttAdv adv = adv ;
-    UttCN n = {s = n.s ! NF Sg Nom nom} ;
+    UttCN n = {s = n.nounpart ! NF Sg Nom nom ++ n.relcl ! Sg ! Nom} ;
     UttCard n = {s = n.s ! Neut ! Inanimate ! Nom} ;
     UttAP ap = {s = ap.s ! AF Nom Inanimate (GSg Neut)} ; ---- gennum ? (AR)
     UttInterj i = i ;

--- a/lib/src/russian/QuestionRus.gf
+++ b/lib/src/russian/QuestionRus.gf
@@ -36,10 +36,10 @@ concrete QuestionRus of Question = CatRus ** open ResRus, Prelude in {
     {s = \\pf => case kakoj.c of {
        Nom => 
         kakoj.s ! AF (extCase pf) okhotnik.anim (gennum okhotnik.g kakoj.n) ++ 
-         okhotnik.s ! NF kakoj.n (extCase pf) nom ; 
+         okhotnik.nounpart ! NF kakoj.n (extCase pf) nom ++ okhotnik.relcl ! kakoj.n ! extCase pf ; 
        _ => 
         kakoj.s ! AF (extCase pf) okhotnik.anim (gennum okhotnik.g kakoj.n) ++ 
-        okhotnik.s ! NF kakoj.n kakoj.c plg };
+        okhotnik.nounpart ! NF kakoj.n kakoj.c plg } ++ okhotnik.relcl ! kakoj.n ! kakoj.c ;
      n = kakoj.n ; 
      p = P3 ;
      pron = False;

--- a/lib/src/russian/ResRus.gf
+++ b/lib/src/russian/ResRus.gf
@@ -287,7 +287,8 @@ oper
 -- Fixing this would require changing the Degree type.
 param
   AdjForm = AF Case Animacy GenNum | AFShort GenNum | AdvF;
-
+  ShortFormPreference = PrefShort | PrefFull ;
+  
 oper
   Complement = {s : Str ; c : Case} ;
 
@@ -318,7 +319,7 @@ oper numAF: AdjForm -> Number = \af ->
    case af of { AdvF => Sg; AFShort gn => numGenNum gn; AF _ _  gn => (numGenNum gn) } ;
 
 oper genAF: AdjForm -> Gender = \af ->
-   case af of { AdvF => Neut; AFShort gn => genGNum gn; AF _ _  gn => (genGNum gn) } ;
+   case af of { AdvF => Neut; AFShort gn => genGNum gn; AF _ _  gn => genGNum gn } ;
 
 oper caseAF: AdjForm -> Case = \af ->
    case af of { AdvF => Nom; AFShort _ => Nom; AF c _ _ => c } ;

--- a/lib/src/russian/StructuralRus.gf
+++ b/lib/src/russian/StructuralRus.gf
@@ -33,11 +33,15 @@ lin
   during_Prep  = { s = ["в течение"] ; c = Gen};
   either7or_DConj  = sd2 "либо" [", либо"]  ** {n = Sg} ;
 -- comma is not visible in GUI!
-  every_Det  = kazhdujDet ** {n = Sg ; g = PNoGen; c= Nom; size = nom} ; 
-  everybody_NP = mkNP Pl (UseN ((eEnd_Decl "вс")**{lock_N=<>})) ;
+  every_Det = {
+    s = \\c,a,g => kazhdujDet.s ! AF c a (gennum g Sg) ;
+    n = Sg ; g = PNoGen ; c = Nom ; size = nom} ;
+  everybody_NP = DetCN (DetQuant IndefArt NumPl) (UseN ((eEnd_Decl "вс")**{lock_N=<>})) ;
   everything_NP  = UsePron (pronVseInanimate ** {lock_Pron=<>}) ;
   everywhere_Adv = ss "везде" ;
-  few_Det = nemnogoSgDet **{lock_Det= <>; n= Sg; g = PNoGen; c = Nom; size = plg};
+  few_Det = {
+    s = \\c,a,g => nemnogoSgDet.s ! AF c a (gennum g Sg) ;
+    n = Sg ; g = PNoGen ; c = Nom ; size = plg} ;
 --- DEPREC  first_Ord = (uy_j_EndDecl  "перв" ) ** {lock_A = <>};  --AStaruyj 
   for_Prep = { s = "для" ; c = Gen };
   from_Prep  = { s = "от" ; c = Gen };
@@ -54,13 +58,17 @@ lin
   in_Prep = { s = "в" ; c = Prepos PrepVNa } ;
   it_Pron    = pronOno ;
   less_CAdv = {s="менее"; p=""} ;
-  many_Det  = mnogoSgDet ** {n = Sg; g = (PGen Neut); c= Gen; size = plg} ; 
+  many_Det  = {
+    s = \\c,a,g => mnogoSgDet.s ! AF c a (gennum g Sg) ;
+    n = Sg; g = (PGen Neut); c = Gen; size = plg} ; 
   more_CAdv = {s="более"; p=""} ;
   most_Predet   = bolshinstvoSgDet ** {n = Sg; g = (PGen Neut); c= Gen; size = plg} ; 
-  -- inanimate, Sg: "большинство телефонов безмолству-ет" 
+  -- inanimate, Sg: "большинство телефонов безмолвству-ет" 
 --  most8many_Det = bolshinstvoPlDet ** {n = Pl; g = (PGen Neut); c= Gen} ;  
   -- animate, Pl: "большинство учащихся хорошо подготовлен-ы"
- much_Det   = mnogoSgDet ** {n = Sg; g = (PGen Neut); c= Gen; size = plg} ; -- same as previous
+ much_Det = {
+    s = \\c,a,g => mnogoSgDet.s ! AF c a (gennum g Sg) ;
+    n = Sg ; g = (PGen Neut) ; c= Gen ; size = plg} ; -- same as previous
  must_VV  = verbDolzhen ;
  no_Utt  = ss ["Нет"] ;
  on_Prep = { s = "на" ; c = Prepos PrepVNa };
@@ -76,8 +84,12 @@ lin
   she_Pron   = pronOna ;
   so_AdA = ss "так";
   somebody_NP = UsePron (pronKtoTo** {lock_Pron = <>});
-  someSg_Det   = nekotorujDet ** {n = Sg; g = PNoGen; c= Nom; size = nom} ;
-  somePl_Det = nekotorujDet ** {n = Pl; g = PNoGen; c= Nom; size = nom} ;  
+  someSg_Det   = {
+    s = \\c,a,g => nekotorujDet.s ! AF c a (gennum g Sg) ;
+    n = Sg ; g = PNoGen ; c= Nom ; size = nom} ;
+  somePl_Det = {
+    s = \\c,a,g => nekotorujDet.s ! AF c a (gennum g Pl) ;
+    n = Pl ; g = PNoGen ; c= Nom ; size = nom} ;  
   something_NP  = UsePron (pronChtoTo** {lock_Pron=<> }) ;
   somewhere_Adv  = ss "где-нибудь" ;
   that_Quant   = totDet ** {n = Sg; g = PNoGen; c= Nom; size = nom} ;
@@ -107,7 +119,7 @@ lin
   whoPl_IP = pron2NounPhraseNum pronKto Animate Pl;
   whoSg_IP = pron2NounPhraseNum pronKto Animate Sg;
   why_IAdv  = ss "почему" ;
-  with_Prep  = { s = "с" ; c = Inst};
+  with_Prep  = {s = pre {#sconsonant => "со" ; ("щ"|"Щ") => "со" ; _ => "с"} ; c = Inst} ;
   without_Prep  = { s = "без" ; c = Gen};
   youPl_Pron  = pronVu Masc;
   yes_Utt  = ss ["Да"] ;
@@ -134,4 +146,9 @@ lin
 ---  AgentPrep = { s = "" ; c = Nom}; -- missing in Russian
 
   lin language_title_Utt = ss "Русский" ;
+  
+oper
+  sconsonant : pattern Str = #(("с"|"з"|"ж"|"ш"|"л"|"ль"|"р"|"м"|"в"|"С"|"З"|"Ж"|"Ш"|"Л"|"Ль"|"Р"|"М"|"В"|"ЛЬ") + 
+               ("б" | "в" | "г" | "д" | "ж" | "з" | "й" | "к" | "л" | "м" | "н" | "п" | "р" | "с" | "т" | "ф" | "х" | "ц" | "ч" | "ш" | "щ" |
+                "Б" | "В" | "Г" | "Д" | "Ж" | "З" | "Й" | "К" | "Л" | "М" | "Н" | "П" | "Р" | "С" | "Т" | "Ф" | "Х" | "Ц" | "Ч" | "Ш" | "Щ")) ;
 }

--- a/lib/src/russian/SymbolRus.gf
+++ b/lib/src/russian/SymbolRus.gf
@@ -9,15 +9,15 @@ lin
   FloatPN i = {s = table  {_ => i.s} ; g = Neut; anim = Inanimate } ;
   NumPN n = {s = table  {_ => n.s ! Neut ! Inanimate ! Nom} ; g = Neut; anim = Inanimate } ;
 
-  CNIntNP cn i = {s = \\cas => cn.s ! NF Sg (extCase cas) nom ++ i.s;
+  CNIntNP cn i = {s = \\cas => cn.nounpart ! NF Sg (extCase cas) nom ++ cn.relcl ! Sg ! extCase cas ++ i.s;
 		  n = Sg ; p = P3 ;
 		  g = PGen cn.g ; anim = cn.anim ; pron = False } ;
-  CNNumNP cn n = {s = \\cas => cn.s ! NF Sg (extCase cas) nom
+  CNNumNP cn n = {s = \\cas => cn.nounpart ! NF Sg (extCase cas) nom ++ cn.relcl ! Sg ! extCase cas
 		    ++ n.s ! cn.g ! cn. anim ! (extCase cas) ;
 		  n = Sg ; p = P3 ;
 		  g = PGen cn.g ; anim = cn.anim ; pron = False } ;
 
-  CNSymbNP d cn ss = {s = \\cas => cn.s ! NF Sg (extCase cas) nom;
+  CNSymbNP d cn ss = {s = \\cas => cn.nounpart ! NF Sg (extCase cas) nom ++ cn.relcl ! Sg ! extCase cas ;
 			n = Sg ; p = P3 ;
 			g = PGen cn.g ; anim = cn.anim ; pron = False } ;
 

--- a/lib/src/russian/VerbRus.gf
+++ b/lib/src/russian/VerbRus.gf
@@ -87,19 +87,19 @@ concrete VerbRus of Verb = CatRus ** open ResRus, Prelude in {
   CompCN zloj ={
  s= \\clf,gn,p => 
    let num = numGenNum gn ;
-       zlojsg = zloj.s ! NF Sg Nom nom ;
-       zlojpl = zloj.s ! NF Pl Nom plg
+       zlojsg = zloj.nounpart ! NF Sg Nom nom ++ zloj.relcl ! Sg ! Nom ;
+       zlojpl = zloj.nounpart ! NF Pl Nom plg ++ zloj.relcl ! Pl ! Nom 
    in
    case clf of { 
 -- person is ignored !
-       ClInfinit => "быть" ++ zloj.s ! NF Sg Inst nom ; 
+       ClInfinit => "быть" ++ zloj.nounpart ! NF Sg Inst nom ++ zloj.relcl ! Sg ! Inst ; 
         ClImper => case gn of 
-          {  (GSg _) => "будь" ++ zloj.s ! NF Sg Inst plg ;
-             GPl => "будьте" ++ zloj.s ! NF Pl Inst plg 
+          {  (GSg _) => "будь" ++ zloj.nounpart ! NF Sg Inst plg ++ zloj.relcl ! Sg ! Inst ;
+             GPl => "будьте" ++ zloj.nounpart ! NF Pl Inst plg ++ zloj.relcl ! Pl ! Inst
           };  
 -- infinitive does not save GenNum, 
 -- but indicative does for the sake of adjectival predication !
-        ClIndic Present _ | ClCondit =>  zloj.s ! NF num Nom nom ;
+        ClIndic Present _ | ClCondit =>  zloj.nounpart ! NF num Nom nom ++ zloj.relcl ! num ! Nom ;
         ClIndic PastRus _ => case gn of
        { (GSg Fem)   => "была" ++ zlojsg ;
           (GSg Masc)  => "был" ++ zlojsg ;


### PR DESCRIPTION
1. Adjectives have now the ShortFormPreference parameter, so that if one of the adjectives in conjunction prefers to stay in the full form, all the rest take the full form as well (e.g. "он классический и элегантный" instead of "он классический и элегантен").
2. Added a postfix record field to adjectives, so that they can be used as postfix adverbs (e.g. "цвета кости")
3. RelCN rule corrected. CN now has separate record fields for the nominal part and possible relative clause, so that further agreement with numerals is correct ("два полотенца, которые..." instead of "два полотенца, которого..."). 
4. Fixed a bug with the numeral "two", since "one" and "two" inflect for gender, and this didn't work for "two".
5. The preposition "с/со" ("with") now is in phonetic harmony with the following word.