### PR TITLE
Fix the Nix build

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,8 +1,8 @@
 { mkDerivation, alex, array, base, bytestring, Cabal, cgi
 , containers, directory, exceptions, filepath, happy, haskeline
-, HTF, httpd-shed, HUnit, json, lifted-base, mtl, network
-, network-uri, old-locale, parallel, pretty, process, random
-, stdenv, terminfo, time, time-compat, unix, utf8-string
+, HTF, httpd-shed, HUnit, json, mtl, network, network-uri
+, old-locale, parallel, pretty, process, random, stdenv, terminfo
+, time, time-compat, unix, utf8-string
 }:
 mkDerivation {
   pname = "gf";
@@ -18,7 +18,7 @@ mkDerivation {
     utf8-string
   ];
   libraryToolDepends = [ alex happy ];
-  executableHaskellDepends = [ base containers lifted-base mtl ];
+  executableHaskellDepends = [ base ];
   testHaskellDepends = [
     base Cabal directory filepath HTF HUnit process
   ];

--- a/gf.nix
+++ b/gf.nix
@@ -1,3 +1,19 @@
-let pkgs = import <nixpkgs> {}; in rec {
-  gf = pkgs.haskellPackages.callPackage ./default.nix {};
+let
+  # We import the package hierarchy from the NIX_PATH.
+  pkgs = import <nixpkgs> {};
+
+  #
+  # The `cgi` package has some out-of-date upper bounds.
+  # Instead of fixing that upstream, we can use the "jailbreak"
+  # function in Nix, which patches away the upper bounds.
+  #
+  # This isn't ideal, but it lets us build the dependency.
+  #
+  jailbreak = pkgs.haskell.lib.doJailbreak;
+  haskellPackages = pkgs.haskellPackages.extend (self: super: {
+    cgi = jailbreak super.cgi;
+  });
+
+in {
+  gf = haskellPackages.callPackage (import ./default.nix) {};
 }


### PR DESCRIPTION
We use the Nix "jailbreak" function to ignore the upper bounds
on the CGI package dependency.