### PR TITLE
(Romance) mv numForms to CommonRomance; rm from Morpho*

### DIFF
--- a/lib/src/catalan/MorphoCat.gf
+++ b/lib/src/catalan/MorphoCat.gf
@@ -3,28 +3,22 @@
 --1 A Simple Catalan Resource Morphology
 --
 -- Aarne Ranta 2002 -- 2005
--- Jordi Saludes 2008: Derived from MorphoSpa. 
+-- Jordi Saludes 2008: Derived from MorphoSpa.
 -- Inari Listenmaa 2012: Added smart paradigms for adjectives.
 --
 -- This resource morphology contains definitions needed in the resource
 -- syntax. To build a lexicon, it is better to use $ParadigmsCat$, which
 -- gives a higher-level access to this module.
 
-resource MorphoCat = CommonRomance, ResCat ** 
+resource MorphoCat = CommonRomance, ResCat **
   open PhonoCat, Prelude, Predef in {
 
   flags optimize=all ; coding=utf8 ;
 
 --2 Nouns
 --
--- The following macro is useful for creating the forms of number-dependent
--- tables, such as common nouns.
--- gcc M2.3
 oper
-  numForms : (_,_ : Str) -> Number => Str = \vi, vins ->
-    table {Sg => vi ; Pl => vins} ; 
-
-  nomCep : Str -> Number => Str = \cep -> 
+  nomCep : Str -> Number => Str = \cep ->
     numForms cep (cep + "s") ;
 
   nomVaca : Str -> Number => Str = \vaca ->
@@ -41,12 +35,12 @@ oper
 
   nomFre : Str -> Number => Str = \fre ->
           numForms fre (fre + "ns") ;
-        
+
   nomCas : Str -> Number => Str = \cas ->
         numForms cas (cas + "os") ;
-        
+
   nomTest : Str -> Number => Str = \test ->
-          numForms test (variants {test + "s"; test + "os"}) ; 
+          numForms test (variants {test + "s"; test + "os"}) ;
 
   nomLlengua: Str -> Number => Str = \llengua ->
         let
@@ -59,22 +53,22 @@ oper
                 fa = Predef.tk 2 faig
         in
         numForms faig (variants {fa + "jos" ; faig + "s"}) ;
-        
+
   nomDesig : Str -> Number => Str = \desig ->
-        let 
+        let
                 desi = Predef.tk 1 desig
         in
         numForms desig (variants {desi + "tjos" ; desi + "gs"}) ;
-        
+
   nomTemps : Str -> Number => Str = \temps ->
         numForms temps temps ;
 
 -- Common nouns are inflected in number and have an inherent gender.
 
-  mkNoun : (Number => Str) -> Gender -> Noun = \noinois,gen -> 
+  mkNoun : (Number => Str) -> Gender -> Noun = \noinois,gen ->
     {s = noinois ; g = gen} ;
 
-  mkNounIrreg : Str -> Str -> Gender -> Noun = \vi,vins -> 
+  mkNounIrreg : Str -> Str -> Gender -> Noun = \vi,vins ->
     mkNoun (numForms vi vins) ;
 
   mkNomReg : Str -> Noun = \noi ->
@@ -110,18 +104,18 @@ oper
 
 --- Then the regular and invariant patterns.
 
-  adjPrim : Str -> Adj = \prim -> 
+  adjPrim : Str -> Adj = \prim ->
     mkAdj prim (prim + "a") (prim + "s") (prim + "es") (prim + "ament") ;
 
   adjBlau : Str -> Str -> Adj = \blau,blava ->
     let blav = Predef.tk 1 blava
     in  mkAdj blau blava (blau + "s") (blav + "es")
              (blava + "ment") ;
-        
+
   adjFondo : Str -> Adj = \fondo ->
     let fond = Predef.tk 1 fondo
     in  adjBlau fondo (fond + "a") ;
-        
+
   adjBo : Str -> Adj = \bo ->
     mkAdj bo (bo + "na") (bo + "ns") (bo + "nes") (bo + "nament") ;
 
@@ -129,10 +123,10 @@ oper
     let fidels : Str = case (last fidel) of {
       _ + ("s"|"ç"|"x") => fidel + "os" ; --feliç; capaç
       _ => fidel + "s"
-    } ; 
-    in  mkAdj fidel fidel fidels fidels 
+    } ;
+    in  mkAdj fidel fidel fidels fidels
              (fidel + "ment") ;
-          
+
   --boig, boja, bojos, boges
   --lleig, lletja, lletjos, lletges
   adjIg : Str -> Str -> Adj = \boig,boja ->
@@ -140,7 +134,7 @@ oper
         llet : Str = tk 1 boj
     in  mkAdj boig (boj + "a") (boj + "os") (llet + "ges")
              (boj + "ament") ;
-            
+
   --públic pública públics públiques
   --llarg llarga llargs llargues
   adjXc : Str -> Adj = \blanc ->
@@ -156,19 +150,19 @@ oper
   --sibilant endings
   adjXs : Str -> Str -> Adj = \famos,famosa ->
     let russ : Str = tk 1 famosa ;
-    in  mkAdj famos famosa (russ + "os") (russ + "es") 
+    in  mkAdj famos famosa (russ + "os") (russ + "es")
              (russ + "ament") ;
 
   -- català catalana catalans catalanes
   adjVn : Str -> Adj = \catalA ->
     let catal : Str = init catalA ;
-        v : Str = unaccent (last catalA) ; 
+        v : Str = unaccent (last catalA) ;
         catalVn : Str = catal + v + "n" ;
-    in mkAdj catalA (catalVn + "a") 
+    in mkAdj catalA (catalVn + "a")
             (catalVn + "s") (catalVn + "es")
             (catalVn + "ament") ;
-            
-  --casat casada ; groc groga  
+
+  --casat casada ; groc groga
   adjCasat : Str -> Adj = \casat ->
     let casa : Str = init casat ;
         casad : Str = case last casat of {
@@ -178,9 +172,9 @@ oper
         grogu : Str = case last casad of {
           "g" => casa + "gu" ;
           _   => casad
-        } ; 
+        } ;
     in mkAdj casat (casad + "a")
-             (casat + "s") (grogu + "es") 
+             (casat + "s") (grogu + "es")
              (casad + "ament") ;
 
   -- francès francesa francesos franceses
@@ -188,18 +182,18 @@ oper
     let franc  : Str = tk 2 francEs ;
         e : Str = last (tk 1 francEs) ;
         v : Str = unaccent e ;
-        francVs : Str = franc + v + "s" 
-    in mkAdj francEs (francVs + "a") 
+        francVs : Str = franc + v + "s"
+    in mkAdj francEs (francVs + "a")
             (francVs + "os") (francVs + "es")
             (francVs + "ament") ;
-            
+
   --europeu europea europeus europees
   adjEuropeu : Str -> Adj = \europeu ->
     let europe : Str = tk 1 europeu ;
     in  mkAdj europeu (europe + "a")
              (europeu + "s") (europe + "es")
              (europe + "ament") ;
-             
+
   --belga belga belgues belgues
   adjBelga : Str -> Adj = \belga ->
     let belg : Str = init belga ;
@@ -207,10 +201,10 @@ oper
           ("g"|"c") => belg + "u" ;
            _        => belg
         } ;
-        belgues : Str = belgu + "es" 
+        belgues : Str = belgu + "es"
     in  mkAdj belga belga belgues belgues (belga + "ment") ;
-  
-  
+
+
   mkAdjReg : Str -> Adj = \prim ->
     case prim of {
         _ + "ll"             => adjPrim prim ; --vell~vella
@@ -219,20 +213,20 @@ oper
         _ + "a"              => adjBelga prim ; --invariable, -es in plural
         _ + ("eu")           => adjFidel prim ; --greu; breu. most "eu" are invariable, europeu and jueu with mk2A.
         _ + ("au"|"ou"|"iu") => adjBlau prim (tk 1 prim + "va"); --blau; nou; viu
-        _ + ("e"|"o")        => adjFondo prim ; 
+        _ + ("e"|"o")        => adjFondo prim ;
         _ + "ig"             => adjIg prim (tk 2 prim + "ja") ; --boig~boja. lleig~lletja with mk2A.
         _ + ("c"|"g")        => adjXc prim ; --públic; llarg. cec~cega with mk2A
         _ + ("n"|"l"|"r"|"s") + "t" => adjPrim prim ; --mort,llest,distint
-        _ + "t"              => adjCasat prim ; --tancat~tancada. petit~petita with mk2A. 
+        _ + "t"              => adjCasat prim ; --tancat~tancada. petit~petita with mk2A.
         _ + ("à"|"é"|"è"|"í"|"ó"|"ò"|"ú") => adjVn prim ; --comú~comuna
         _ + ("à"|"é"|"è"|"í"|"ó"|"ò"|"ú") + "s" => adjFrances prim ;
         _ + ("s"|"x")        => adjXs prim (prim + "a") ; --divers~diversa
-        _                    => adjPrim prim  
+        _                    => adjPrim prim
         } ;
 
   --Used for the following:
   --diferent diferent : doesn't end in l/n/ç/eu but has invariant feminine
-  --petit petita petits petites : voiceless plosive in the stem. 
+  --petit petita petits petites : voiceless plosive in the stem.
   --ridícul ridícula : ends in l/n/ç but is not invariant.
   --lleig lletja : the geminated variant of boig boja
   --bo bona ; pla plana : like adjVn, but for one syllable words
@@ -251,7 +245,7 @@ oper
         <_ + "eu", _ + "ea"> => adjEuropeu petit ; --europeu~europea
         <_ + "s" , _> => adjXs petit petita ; --rus~russa
         <_ + "c" , _ + "ga"> => adjCasat petit ; --groc~groga
-        _       => mkAdjReg petit 
+        _       => mkAdjReg petit
     } ;
 
 oper unaccent : Str -> Str = \vocal ->
@@ -270,7 +264,7 @@ oper unaccent : Str -> Str = \vocal ->
 -- All the eight personal pronouns can be built by the following macro.
 -- The use of "en" as atonic genitive is debatable.
 
-  mkPronoun : (_,_,_,_,_,_,_,_ : Str) -> 
+  mkPronoun : (_,_,_,_,_,_,_,_ : Str) ->
               Gender -> Number -> Person -> Pronoun =
     \ell,el,li,Ell,son,sa,elsSeus,lesSeves,g,n,p ->
     let

--- a/lib/src/french/MorphoFre.gf
+++ b/lib/src/french/MorphoFre.gf
@@ -8,7 +8,7 @@
 -- syntax. To build a lexicon, it is better to use $ParadigmsFre$, which
 -- gives a higher-level access to this module.
 
-resource MorphoFre = CommonRomance, ResFre ** 
+resource MorphoFre = CommonRomance, ResFre **
   open PhonoFre, Prelude, Predef in {
 
 flags optimize=noexpand ;
@@ -24,41 +24,34 @@ oper
 
 
 --2 Nouns
---
--- The following macro is useful for creating the forms of number-dependent
--- tables, such as common nouns.
 
-  numForms : Str -> Str -> Number => Str = \bon,bons ->
-    table {Sg => bon ; Pl => bons} ; 
-
--- For example, the regular noun forms are defined as follows:
-
+-- regular noun forms are defined as follows:
   nomReg : Str -> Number => Str = \bu -> numForms bu (bu + "s") ;
 
 -- Common nouns are inflected in number and have an inherent gender.
 
   CNom = {s : Number => Str ; g : Gender} ;
 
-  mkCNom : (Number => Str) -> Gender -> CNom = \mecmecs,gen -> 
+  mkCNom : (Number => Str) -> Gender -> CNom = \mecmecs,gen ->
     {s = mecmecs ; g = gen} ;
 
-  mkCNomIrreg : Str -> Str -> Gender -> CNom = \mec,mecs -> 
+  mkCNomIrreg : Str -> Str -> Gender -> CNom = \mec,mecs ->
     mkCNom (numForms mec mecs) ;
 
-  mkCNomReg : Str -> Gender -> CNom = \mec -> 
+  mkCNomReg : Str -> Gender -> CNom = \mec ->
     mkCNom (nomReg mec) ;
 
-  mkCNomNiveau : Str -> Gender -> CNom = \niveau -> 
+  mkCNomNiveau : Str -> Gender -> CNom = \niveau ->
     mkCNomIrreg niveau (niveau + "x") ;
 
-  mkCNomCheval : Str -> Gender -> CNom = \cheval -> 
-    let {cheva = Predef.tk 1 cheval} in 
+  mkCNomCheval : Str -> Gender -> CNom = \cheval ->
+    let {cheva = Predef.tk 1 cheval} in
     mkCNomIrreg cheval (cheva + "ux") ;
 
-  mkCNomInvar : Str -> Gender -> CNom = \cas -> 
+  mkCNomInvar : Str -> Gender -> CNom = \cas ->
     mkCNomIrreg cas cas ;
 
-  mkNomReg : Str -> Gender -> CNom = \cas -> 
+  mkNomReg : Str -> Gender -> CNom = \cas ->
     let cass = case Predef.dp 2 cas of {
       "al" => init cas + "ux" ;
       "au" => cas + "x" ;
@@ -72,7 +65,7 @@ oper
       }
     }
     in mkCNomIrreg cas cass ;
-      
+
 
 --2 Adjectives
 --
@@ -97,12 +90,12 @@ oper
       })
     } ;
 
-  adjInvar : Str -> Gender => Number => Str = \bien -> 
+  adjInvar : Str -> Gender => Number => Str = \bien ->
     \\_,_ => bien ;
 
 -- Adjectives themselves are records. Here the most common cases:
 
-  adjGrand : Str -> Adj = \grand -> 
+  adjGrand : Str -> Adj = \grand ->
     let grande = case last grand of {
       "e" => grand ;
       _ => grand + "e"
@@ -112,32 +105,32 @@ oper
 
 -- Masculine form used for adverbial; also covers "carré".
 
-  adjJoli : Str -> Adj = \joli -> 
+  adjJoli : Str -> Adj = \joli ->
     mkAdj joli (joli + "s") (joli + "e") (joli + "ment") ;
 
   adjHeureux : Str -> Adj = \heureux ->
-    let {heureu = Predef.tk 1 heureux} in 
+    let {heureu = Predef.tk 1 heureux} in
     mkAdj heureux heureux (heureu+"se") (heureu+"sement") ;
 
   adjBanal : Str -> Adj = \banal ->
-    let {bana = Predef.tk 1 banal} in 
+    let {bana = Predef.tk 1 banal} in
     mkAdj banal (bana + "ux") (banal+"e") (banal+"ement") ;
 
-  adjJeune : Str -> Adj = \jeune -> 
+  adjJeune : Str -> Adj = \jeune ->
     mkAdj jeune (jeune+"s") jeune (jeune+"ment") ;
 
-  adjIndien : Str -> Adj = \indien -> 
+  adjIndien : Str -> Adj = \indien ->
     mkAdj indien (indien+"s") (indien+"ne") (indien+"nement") ;
-    
-  adjTel : Str -> Adj = \tel -> 
+
+  adjTel : Str -> Adj = \tel ->
     mkAdj tel (tel+"s") (tel+"le") (tel+"lement") ;
 
-  adjFrancais : Str -> Adj = \francais -> 
+  adjFrancais : Str -> Adj = \francais ->
     mkAdj francais francais (francais+"e") (francais+"ement") ;
 
   adjCher : Str -> Adj = \cher ->
     let {ch = Predef.tk 2 cher} in
-    mkAdj cher (cher + "s") (ch + "ère") (ch + "èrement") ; 
+    mkAdj cher (cher + "s") (ch + "ère") (ch + "èrement") ;
 
   adjPublic : Str -> Adj = \public ->
     let publique = init public + "que" in
@@ -175,7 +168,7 @@ oper
 -- All the eight personal pronouns can be built by the following macro.
 -- The use of "en" as atonic genitive is debatable.
 
-  mkPronoun : (_,_,_,_,_,_,_ : Str) -> 
+  mkPronoun : (_,_,_,_,_,_,_ : Str) ->
               Gender -> Number -> Person -> Pronoun =
     \il,le,lui,Lui,son,sa,ses,g,n,p ->
     let
@@ -238,8 +231,8 @@ param
   TSubj    = SPres | SImparf ;
   TPart    = PPres | PPasse Gender Number ;
   VForm    = Inf
-           | Indi Temps Number Person 
-           | Condi Number Person 
+           | Indi Temps Number Person
+           | Condi Number Person
            | Subjo TSubj Number Person
            | Imper NumPersI
            | Part TPart ;
@@ -247,13 +240,13 @@ param
 -- This is a conversion to the type in $CommonRomance$.
 
 oper
-  vvf : (VForm => Str) -> (VF => Str) = \aller -> table { 
+  vvf : (VForm => Str) -> (VF => Str) = \aller -> table {
     VInfin True => case last (aller ! Indi Presn Sg P3) of {  --- terrible hack to store the binding here... 30/11/2014
       "a" | "e" => bindHyphensT ; -- parle-t-il, va-t-il
       _ => bindHyphen  -- prend-il
       } ;
     VInfin False => aller ! Inf ;
-    VFin (VPres   Indic) n p => aller ! Indi Presn n p ; 
+    VFin (VPres   Indic) n p => aller ! Indi Presn n p ;
     VFin (VPres   Subjunct) n p => aller ! Subjo SPres n p ;
     VFin (VImperf Indic) n p => aller ! Indi Imparf n p ;     --# notpresent
     VFin (VImperf Subjunct) n p => aller ! Subjo SImparf n p ;  --# notpresent
@@ -269,10 +262,10 @@ oper
 
 -- the worst case
 
-  mkVerb12 : 
+  mkVerb12 :
     (tenir,tiens,tient,tenons,tenez,tiennent,tienne,tenions,tiensI,tint,tiendra,tenu : Str) -> Verbe =
-    \tenir,tiens,tient,tenons,tenez,tiennent,tienne,tenions,tiensI,tint,tiendra,tenu -> 
-    let 
+    \tenir,tiens,tient,tenons,tenez,tiennent,tienne,tenions,tiensI,tint,tiendra,tenu ->
+    let
       tiens2 : Str = case tiens of {
         _ + "e" => tiens + "s" ;
         _       => tiens
@@ -317,7 +310,7 @@ oper
       } ;
 
   mkVerb7 : (tenir,tiens,tenons,tiennent,tint,tiendra,tenu : Str) -> Verbe =
-    \tenir,tiens,tenons,tiennent,tint,tiendra,tenu -> 
+    \tenir,tiens,tenons,tiennent,tint,tiendra,tenu ->
     let
       tient : Str = case tiens of {
         _ + "e"                  => tiens ;
@@ -389,12 +382,12 @@ oper
         }
       } ;
 
-  affixPlMes : (_,_ : Str) -> Affixe = 
+  affixPlMes : (_,_ : Str) -> Affixe =
      \è, â -> lesAffixes (â + "mes") (â + "tes") (è + "rent") ;
 
   affixPasseAi : Number => Affixe = table {
       Sg => affixSgAi ;
-      Pl => affixPlMes "è" "â" 
+      Pl => affixPlMes "è" "â"
       } ;
 
   affixPasseS : (i,î : Str) -> Number => Affixe = \i,î -> table {
@@ -421,13 +414,13 @@ oper
 
   affixPasseU : AffixPasse = affixPasse "u" "û" ;
 
-  affixPasseNonExist : AffixPasse = 
-    let {aff : Number => Affixe = 
+  affixPasseNonExist : AffixPasse =
+    let {aff : Number => Affixe =
                  table {_ => lesAffixes nonExist nonExist nonExist}} in
       {ps = aff ; si = aff} ;
 
   affixImper : NumPersI => Str = table {
-     SgP2 => "e" ; 
+     SgP2 => "e" ;
      PlP1 => "ons" ;
      PlP2 => "ez"
      } ;
@@ -437,7 +430,7 @@ oper
        Pl => table {
          P3 => v + "ont" ;
          p  => all + affixPlOns ! p
-         } 
+         }
        } ;
 
 }

--- a/lib/src/italian/MorphoIta.gf
+++ b/lib/src/italian/MorphoIta.gf
@@ -18,15 +18,7 @@ resource MorphoIta = CommonRomance, ResIta **
 
 --2 Nouns
 --
--- The following macro is useful for creating the forms of number-dependent
--- tables, such as common nouns.
-
 oper
-  numForms : (_,_ : Str) -> Number => Str = \vino, vini ->
-    table {Sg => vino ; Pl => vini} ;
-
--- For example:
-
   nomVino : Str -> Number => Str = \vino -> let {vin = Predef.tk 1 vino} in
     numForms vino (vin + "i") ;
 

--- a/lib/src/portuguese/MorphoPor.gf
+++ b/lib/src/portuguese/MorphoPor.gf
@@ -19,9 +19,6 @@ resource MorphoPor = CommonRomance, ResPor **
 -- number-dependent tables, such as common nouns.
 
 oper
-  numForms : (_,_ : Str) -> Number => Str = \campus, campi ->
-    table {Sg => campus ; Pl => campi} ;
-
 -- For example:
   nomVinho : Str -> Number => Str = \vinho ->
     numForms vinho (vinho + "s") ;

--- a/lib/src/romance/CommonRomance.gf
+++ b/lib/src/romance/CommonRomance.gf
@@ -24,8 +24,8 @@ param
 
   Direct = DDir | DInv ;
 
--- Adjectives are inflected in gender and number, and there is also an 
--- adverbial form (e.g. "infiniment"), which has different paradigms and 
+-- Adjectives are inflected in gender and number, and there is also an
+-- adverbial form (e.g. "infiniment"), which has different paradigms and
 -- can even be irregular ("bien").
 -- Comparative adjectives are moreover inflected in degree
 -- (which in Romance is usually syntactic, though).
@@ -61,18 +61,18 @@ oper
     AF g n => aagr g n ;
     _      => aagr Masc Sg -- "le plus lentement"
     } ;
-  
-  conjGender : Gender -> Gender -> Gender = \m,n -> 
+
+  conjGender : Gender -> Gender -> Gender = \m,n ->
     case m of {
       Fem => n ;
-      _ => Masc 
+      _ => Masc
       } ;
 
 
---3 Verbs 
+--3 Verbs
 --
--- In the current syntax, we use 
--- a reduced conjugation with only the present tense infinitive, 
+-- In the current syntax, we use
+-- a reduced conjugation with only the present tense infinitive,
 -- indicative, subjunctive, and imperative forms.
 -- But our morphology has full Bescherelle conjunctions:
 -- so we use a coercion between full and reduced verbs.
@@ -84,17 +84,17 @@ oper
 -- For Italian contracted forms, $VInfin$ should have
 -- an alternative form, whose proper place is $Diff$.
 
-param 
+param
   VF =
      VInfin Bool
-   | VFin   TMood Number Person 
-   | VImper NumPersI 
-   | VPart  Gender Number 
+   | VFin   TMood Number Person
+   | VImper NumPersI
+   | VPart  Gender Number
    | VGer
    | VPresPart  --- = VGer except in Italian
    ;
 
-  TMood = 
+  TMood =
      VPres  Mood
    | VImperf Mood   --# notpresent
    | VPasse  --# notpresent
@@ -111,7 +111,7 @@ param
    | VPInfinit Anteriority Bool ;
 
   RTense =
-     RPres 
+     RPres
    | RPast   --# notpresent
    | RPasse  --# notpresent
    | RFut    --# notpresent
@@ -129,7 +129,7 @@ oper
 
   verbAgr : Agr -> {g : Gender ; n : Number ; p : Person} = \a -> a ;
 
-  conjAgr : Agr -> Agr -> Agr = \a,b -> 
+  conjAgr : Agr -> Agr -> Agr = \a,b ->
     {g = conjGender a.g b.g ; n = conjNumber a.n b.n ; p = conjPerson a.p b.p} ;
 
   Ag : Gender -> Number -> Person -> Agr = \g,n,p -> {g = g ; n = n ; p = p} ;
@@ -137,11 +137,11 @@ oper
 -- The imperative forms depend on number and person.
 
   vImper : Number -> Person -> VF = \n,p -> case <n,p> of {
-    <Sg,P2> => VImper SgP2 ; 
-    <Pl,P1> => VImper PlP1 ; 
+    <Sg,P2> => VImper SgP2 ;
+    <Pl,P1> => VImper PlP1 ;
     <Pl,P2> => VImper PlP2 ;
     _       => VFin (VPres Conjunct) n p
-    } ; 
+    } ;
 
 {-
 param
@@ -201,9 +201,14 @@ oper
   oper
     genForms : Str -> Str -> Gender => Str = \bon,bonne ->
       table {
-        Masc => bon ; 
+        Masc => bon ;
         Fem => bonne
-        } ; 
+      } ;
+
+    -- The following macro is useful for creating the forms of
+    -- number-dependent tables, such as common nouns.
+    numForms : (_,_ : Str) -> Number => Str = \campus, campi ->
+      table {Sg => campus ; Pl => campi} ;
 
     aagrForms : (x1,_,_,x4 : Str) -> (AAgr => Str) = \tout,toute,tous,toutes ->
       table {
@@ -215,7 +220,7 @@ oper
 
     Adj = {s : AForm => Str} ;
 
-    appVPAgr : VPAgr -> AAgr -> AAgr = \vp,agr -> 
+    appVPAgr : VPAgr -> AAgr -> AAgr = \vp,agr ->
       case vp of {
         VPAgrSubj     => agr ;
         VPAgrClit g n => {g = g ; n = n}
@@ -232,13 +237,12 @@ oper
     bindIf : Bool -> Str = \b -> if_then_Str b BIND [] ;
 
   param
-    VPAgr = 
+    VPAgr =
        VPAgrSubj                    -- elle est partie, elle s'est vue
      | VPAgrClit Gender Number ;    -- elle a dormi; elle les a vues
 
 -- Polarity: three values (Fre positive,ne-pas,ne), presence of polarity element line "aucun"
 
-  param RPolarity = RPos | RNeg Bool ; -- RNeg True = "ne", RNeg False = "ne - pas" 
+  param RPolarity = RPos | RNeg Bool ; -- RNeg True = "ne", RNeg False = "ne - pas"
 
 }
-

--- a/lib/src/spanish/MorphoSpa.gf
+++ b/lib/src/spanish/MorphoSpa.gf
@@ -8,7 +8,7 @@
 -- syntax. To build a lexicon, it is better to use $ParadigmsSpa$, which
 -- gives a higher-level access to this module.
 
-resource MorphoSpa = CommonRomance, ResSpa ** 
+resource MorphoSpa = CommonRomance, ResSpa **
   open PhonoSpa, Prelude, Predef,
   CatSpa in {
 
@@ -17,20 +17,12 @@ resource MorphoSpa = CommonRomance, ResSpa **
 
 
 --2 Nouns
---
--- The following macro is useful for creating the forms of number-dependent
--- tables, such as common nouns.
 
 oper
-  numForms : (_,_ : Str) -> Number => Str = \vino, vini ->
-    table {Sg => vino ; Pl => vini} ; 
-
--- For example:
-
-  nomVino : Str -> Number => Str = \vino -> 
+  nomVino : Str -> Number => Str = \vino ->
     numForms vino (vino + "s") ;
 
-  nomPilar : Str -> Number => Str = \pilar -> 
+  nomPilar : Str -> Number => Str = \pilar ->
     numForms pilar (pilar + "es") ;
 
   nomTram : Str -> Number => Str = \tram ->
@@ -38,10 +30,10 @@ oper
 
 -- Common nouns are inflected in number and have an inherent gender.
 
-  mkNoun : (Number => Str) -> Gender -> Noun = \mecmecs,gen -> 
+  mkNoun : (Number => Str) -> Gender -> Noun = \mecmecs,gen ->
     {s = mecmecs ; g = gen} ;
 
-  mkNounIrreg : Str -> Str -> Gender -> Noun = \mec,mecs -> 
+  mkNounIrreg : Str -> Str -> Gender -> Noun = \mec,mecs ->
     mkNoun (numForms mec mecs) ;
 
   mkNomReg : Str -> Noun = \mec ->
@@ -75,15 +67,15 @@ oper
 
 -- Then the regular and invariant patterns.
 
-  adjSolo : Str -> Adj = \solo -> 
-    let 
+  adjSolo : Str -> Adj = \solo ->
+    let
       sol = Predef.tk 1 solo
     in
     mkAdj solo (sol + "a") (sol + "os") (sol + "as") (sol + "amente") ;
 
-  -- masculine and feminine are identical: 
+  -- masculine and feminine are identical:
   -- adjectives ending with -e, -a and many but not all that end in a consonant
-  adjUtil : Str -> Str -> Adj = \util,utiles -> 
+  adjUtil : Str -> Str -> Adj = \util,utiles ->
     mkAdj util util utiles utiles (util + "mente") ;
 
   -- adjectives that end in consonant but have different masc and fem forms
@@ -91,15 +83,15 @@ oper
   adjEspanol : Str -> Str -> Adj = \espanol,espanola ->
     mkAdj espanol espanola (espanol + "es") (espanol + "as") (espanola + "mente") ;
 
-  adjBlu : Str -> Adj = \blu -> 
-    mkAdj blu blu blu blu blu ; --- 
+  adjBlu : Str -> Adj = \blu ->
+    mkAdj blu blu blu blu blu ; ---
 
  -- francés francesa franceses francesas
   adjEs : Str -> Adj = \francEs ->
     let franc  : Str = Predef.tk 2 francEs ;
         frances : Str = franc + "es" ;
     in mkAdj francEs (frances + "a") (frances + "es") (frances + "as") (frances + "amente") ;
- 
+
 
    -- alemán alemana alemanes alemanas
   adjVn : Str -> Adj = \alemAn ->
@@ -117,7 +109,7 @@ oper
     in mkAdj alemAn (alemVn + "a") (alemVn + "es")
             (alemVn + "as") (alemVn + "amente") ;
 
-  mkAdjReg : Str -> Adj = \solo -> 
+  mkAdjReg : Str -> Adj = \solo ->
     case solo of {
       _ + "o" => adjSolo solo ;
       _ + ("e" | "a") => adjUtil solo (solo + "s") ;
@@ -132,7 +124,7 @@ oper
 -- The use of "ne" as atonic genitive is debatable.
 -- We follow the rule that the atonic nominative is empty.
 
-  mkPronoun : (_,_,_,_,_,_,_,_ : Str) -> 
+  mkPronoun : (_,_,_,_,_,_,_,_ : Str) ->
               Gender -> Number -> Person -> Pronoun =
     \il,le,lui,Lui,son,sa,ses,see,g,n,p ->
     let
@@ -148,7 +140,7 @@ oper
        <Sg,Masc> => son ;
        <Sg,Fem>  => sa ;
        <Pl,Masc> => ses ;
-       <Pl,Fem>  => see 
+       <Pl,Fem>  => see
        } ;
 
     a = Ag g n p ;
@@ -169,7 +161,7 @@ oper
     } ;
 
   mkQuantifier : (ese,esa,esos,esas : Str) -> Quant = \ese,esa,esos,esas->
-    let 
+    let
       se  : Str = Predef.drop 1 ese ;
       sa  : Str = Predef.drop 1 esa ;
       sos : Str = Predef.drop 1 esos ;
@@ -177,7 +169,7 @@ oper
       E   : Str = "é" ;
       attrforms : Number => Gender => Case => Str = table {
         Sg => \\g,c => prepCase c ++ genForms ese esa ! g ;
-        Pl => \\g,c => prepCase c ++ genForms esos esas ! g ---- 
+        Pl => \\g,c => prepCase c ++ genForms esos esas ! g ----
         } ;
       npforms : Number => Gender => Case => Str = table {
         Sg => \\g,c => prepCase c ++ genForms (E + se)  (E + sa)  ! g ;
@@ -195,7 +187,7 @@ oper
       s2 = [] ;
       isNeg = neg
       } ;
-      
+
    mkIDet : (cuantos, cuantas : Str) -> Number -> IDet = \cuantos,cuantas,number ->
      lin IDet {
        s = \\g,c => prepCase c ++ genForms cuantos cuantas ! g ;


### PR DESCRIPTION
- removed numForms from Morpho{Fre,Spa,Por}
- added numForms to CommonRomance

#### notes
- LangPor and LangSpa compile (can't test LangFre on my computer) -- although now we have CI, so I don't have to check anymore, right?
- again my emacs removes all trailing whitespace and makes the `diff` a mess: you can use `git diff --ignore-space-at-eol` on the terminal for a cleaner `diff`
- I wonder how we can prevent this kind of repetition across GF modules... I think something akin to haddock and hoogle would help, though.